### PR TITLE
feat(short name): add short path to stack frames

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 grpcio>=1.51.3
-deep-proto>=1.0.0
+deep-proto>=1.0.2
 protobuf>=3.20.3

--- a/src/deep/api/tracepoint/eventsnapshot.py
+++ b/src/deep/api/tracepoint/eventsnapshot.py
@@ -99,6 +99,7 @@ class StackFrame:
 
     def __init__(self,
                  file_name,
+                 short_path,
                  method_name,
                  line_number,
                  variables,
@@ -111,6 +112,7 @@ class StackFrame:
                  app_frame=False
                  ):
         self._file_name = file_name
+        self._short_path = short_path
         self._method_name = method_name
         self._line_number = line_number
         self._class_name = class_name
@@ -125,6 +127,10 @@ class StackFrame:
     @property
     def file_name(self):
         return self._file_name
+
+    @property
+    def short_path(self):
+        return self._short_path
 
     @property
     def method_name(self):

--- a/src/deep/processor/frame_collector.py
+++ b/src/deep/processor/frame_collector.py
@@ -11,7 +11,7 @@
 #      GNU Affero General Public License for more details.
 
 import abc
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
 
 from deep import logging
 from deep.api.tracepoint import StackFrame, WatchResult, Variable, VariableId
@@ -102,7 +102,7 @@ class FrameCollector(Collector):
         self._has_time_exceeded = duration > self._frame_config.max_tp_process_time
         return self._has_time_exceeded
 
-    def is_app_frame(self, filename: str) -> Tuple[bool, str | None]:
+    def is_app_frame(self, filename: str) -> Tuple[bool, Optional[str]]:
         in_app_include = self._config.IN_APP_INCLUDE
         in_app_exclude = self._config.IN_APP_EXCLUDE
 

--- a/src/deep/processor/frame_collector.py
+++ b/src/deep/processor/frame_collector.py
@@ -11,7 +11,7 @@
 #      GNU Affero General Public License for more details.
 
 import abc
-from typing import Dict
+from typing import Dict, Tuple
 
 from deep import logging
 from deep.api.tracepoint import StackFrame, WatchResult, Variable, VariableId
@@ -90,8 +90,9 @@ class FrameCollector(Collector):
         # only process vars if we are under the time limit
         if process_vars and not self.time_exceeded():
             var_ids = self.process_frame_variables_breadth_first(f_locals)
-
-        return StackFrame(filename, func_name, lineno, var_ids, class_name, app_frame=self.is_app_frame(filename))
+        short_path, app_frame = self.parse_short_name(filename)
+        return StackFrame(filename, short_path, func_name, lineno, var_ids, class_name,
+                          app_frame=app_frame)
 
     def time_exceeded(self):
         if self._has_time_exceeded:
@@ -101,19 +102,19 @@ class FrameCollector(Collector):
         self._has_time_exceeded = duration > self._frame_config.max_tp_process_time
         return self._has_time_exceeded
 
-    def is_app_frame(self, filename):
+    def is_app_frame(self, filename: str) -> Tuple[bool, str | None]:
         in_app_include = self._config.IN_APP_INCLUDE
         in_app_exclude = self._config.IN_APP_EXCLUDE
 
         for path in in_app_exclude:
             if filename.startswith(path):
-                return False
+                return False, path
 
         for path in in_app_include:
-            if filename.starstwith(path):
-                return True
+            if filename.startswith(path):
+                return True, path
 
-        return True
+        return True, None
 
     def process_frame_variables_breadth_first(self, f_locals):
         """
@@ -212,3 +213,9 @@ class FrameCollector(Collector):
 
     def append_variable(self, var_id, variable):
         self._var_lookup[var_id] = variable
+
+    def parse_short_name(self, filename) -> Tuple[str, bool]:
+        is_app_frame, match = self.is_app_frame(filename)
+        if match is not None:
+            return filename[len(match):], is_app_frame
+        return filename, is_app_frame

--- a/src/deep/push/__init__.py
+++ b/src/deep/push/__init__.py
@@ -34,9 +34,10 @@ def convert_tracepoint(tracepoint: TrPoCo):
 
 
 def convert_frame(frame: StFr):
-    return StackFrame(file_name=frame.file_name, method_name=frame.method_name, line_number=frame.line_number,
-                      class_name=frame.class_name, is_async=frame.is_async, column_number=frame.column_number,
-                      variables=[convert_variable_id(v) for v in frame.variables], app_frame=frame.app_frame,
+    return StackFrame(file_name=frame.file_name, short_path=frame.short_path, method_name=frame.method_name,
+                      line_number=frame.line_number, class_name=frame.class_name, is_async=frame.is_async,
+                      column_number=frame.column_number, variables=[convert_variable_id(v) for v in frame.variables],
+                      app_frame=frame.app_frame,
                       transpiled_file_name=frame.transpiled_file_name,
                       transpiled_line_number=frame.transpiled_line_number,
                       transpiled_column_number=frame.transpiled_column_number,


### PR DESCRIPTION
Adding short paths allows the UI to display a shorter version of the paths. As they can be very long. The clients can now shorten the file paths to improve the readability of the data.