### PR TITLE
feat(dev): add option to not attach trace function

### DIFF
--- a/src/deep/processor/trigger_handler.py
+++ b/src/deep/processor/trigger_handler.py
@@ -58,6 +58,10 @@ class TriggerHandler:
         self._config.add_listener(TracepointHandlerUpdateListener(self))
 
     def start(self):
+        # if we call settrace we cannot use debugger,
+        # so we allow the settrace to be disabled, so we can at least debug around it
+        if self._config.NO_TRACE:
+            return
         sys.settrace(self.trace_call)
         threading.settrace(self.trace_call)
 


### PR DESCRIPTION
When debugging we cannot use `settrace` which is used to collect data. Adding this option allows us to debug around what we cannot.