### PR TITLE
fix(build): revert to use defined deps in toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,12 @@ lint:
 .PHONY: flake
 flake: lint
 
+.PHONY: build
+build:
+	rm -Rf $(ROOT_DIR)/dist
+
+	python -m build $(ROOT_DIR)
+
 .PHONY: check-python-vars
 check-python-vars:
 ifndef TWINE_USER

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,12 @@ classifiers = [
 ]
 dynamic = [
     "version",
-    "dependencies"
+]
+
+dependencies = [
+    "grpcio>=1.51.3",
+    "deep-proto>=1.0.5",
+    "protobuf>=3.20.3"
 ]
 
 [tool.hatch.build.targets.sdist]
@@ -43,10 +48,6 @@ packages = ["src/deep"]
 # read version from version.py file
 [tool.hatch.version]
 path = "src/deep/version.py"
-
-# read dependencies from reuirements.txt
-[tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt"]}
 
 [tool.pytest.ini_options]
 pythonpath = [


### PR DESCRIPTION
using dynamic dependencies did not work, they were not installed when using the agent in another app.

Add build step in make to build the wheel locally for local testing.

<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with main
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
